### PR TITLE
Code tidying and renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This library started as a fork of [HSM.jl](https://github.com/AndrewWasHere/HSM.
 ## Usage
 
 To use this package, define a state machine type. This can contain any state fields you might want to use in your application.
-It must inherit from `Hsm.AbstractStateMachine` and contain a field called `ctx` of type `Hsm.StateMachineContext`:
+It must inherit from `Hsm.AbstractStateMachine` and contain a field called `context` of type `Hsm.StateMachineContext`:
 
 ```julia
 using Hsm
 
 mutable struct MyStateMachine <: Hsm.AbstractStateMachine
-    ctx::Hsm.StateMachineContext
+    context::Hsm.StateMachineContext
     # Your state variables here
     foo::Int
 end
@@ -41,7 +41,7 @@ Now, define the ways in which your state machine enters and exits those
 
 Hsm.register_events!(mysm) do sm
 
-    Hsm.on_initialize!(sm, :State1) do
+    Hsm.on_initial!(sm, :State1) do
         # When initializing the outer State1, let's
         # immediately transition into this sub-state.
         Hsm.transition!(sm, :State1_substate1)

--- a/src/Hsm.jl
+++ b/src/Hsm.jl
@@ -2,10 +2,8 @@ module Hsm
 using FunctionWrappers
 using Setfield
 
-include("types.jl")
 include("machine.jl")
 include("state.jl")
 include("build-sm.jl")
-
 
 end # module Hsm

--- a/src/build-sm.jl
+++ b/src/build-sm.jl
@@ -1,33 +1,45 @@
+using FunctionWrappers: FunctionWrapper
 
 function add_state!(sm::AbstractStateMachine; name::Symbol, ancestor::Symbol)
-    push!(sm.ctx.states, (;name, ancestor))
+    push!(sm.context.states, (; name, ancestor))
+    return
 end
 
-using FunctionWrappers: FunctionWrapper
-function on_event!(callback::Base.Callable, sm::AbstractStateMachine, state_name::Symbol, event_name::Symbol)
+function on_event!(
+    callback,
+    sm::AbstractStateMachine,
+    state_name::Symbol,
+    event_name::Symbol,
+)
     # TODO: In reality, a SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}
     fw = FunctionWrapper{EventHandled,Tuple{Vector{UInt8}}}(callback) # Works!
     # fw = FunctionWrapper{EventHandled,Tuple{Vector{UInt8},typeof(typer)}}(our_callback)
     # fw = @cfunction($our_callback, Cvoid, (Vector{UInt8},))
-    push!(sm.ctx.event_callbacks, (; name=event_name, state=state_name, callback=fw))
-    return nothing
-end
-function on_entry!(callback::Base.Callable, sm::AbstractStateMachine, state_name::Symbol,)
-    fw = FunctionWrapper{Nothing,Tuple{}}(callback) 
-    push!(sm.ctx.enter_callbacks, (; state=state_name, callback=fw))
-    return nothing
-end
-function on_exit!(callback::Base.Callable, sm::AbstractStateMachine, state_name::Symbol,)
-    fw = FunctionWrapper{Nothing,Tuple{}}(callback) 
-    push!(sm.ctx.exit_callbacks, (; state=state_name, callback=fw))
-    return nothing
-end
-function on_initialize!(callback::Base.Callable, sm::AbstractStateMachine, state_name::Symbol,)
-    fw = FunctionWrapper{Nothing,Tuple{}}(callback) 
-    push!(sm.ctx.initialize_callbacks, (; state=state_name, callback=fw))
-    return nothing
+    push!(
+        sm.context.event_callbacks,
+        (; name = event_name, state = state_name, callback = fw),
+    )
+    return
 end
 
-function register_events!(callback, hsm1)
-    callback(hsm1)
+function on_entry!(callback, sm::AbstractStateMachine, state_name::Symbol)
+    fw = FunctionWrapper{Nothing,Tuple{}}(callback)
+    push!(sm.context.entry_callbacks, (; state = state_name, callback = fw))
+    return
+end
+
+function on_exit!(callback, sm::AbstractStateMachine, state_name::Symbol)
+    fw = FunctionWrapper{Nothing,Tuple{}}(callback)
+    push!(sm.context.exit_callbacks, (; state = state_name, callback = fw))
+    return
+end
+
+function on_initial!(callback, sm::AbstractStateMachine, state_name::Symbol)
+    fw = FunctionWrapper{Nothing,Tuple{}}(callback)
+    push!(sm.context.initial_callbacks, (; state = state_name, callback = fw))
+    return
+end
+
+function register_events!(callback, sm)
+    callback(sm)
 end

--- a/src/machine.jl
+++ b/src/machine.jl
@@ -69,35 +69,6 @@ function dispatch!(sm::AbstractStateMachine, event, payload = empty_payload)
     do_event!(sm, current(sm), event, payload)
 end
 
-function do_event_r!(
-    sm::AbstractStateMachine,
-    source::Union{Symbol,AbstractString},
-    event::Symbol,
-    payload,
-) # TODO: payload typed
-    if source === :Root
-        @warn "Event not handled by any states up to Root" event maxlog = 1
-        return
-    end
-
-    source!(sm, source)
-
-    # Find the main source state by calling on_event! until the event is handled
-    # on_event!
-    handled = NotHandled
-    for cb in sm.context.event_callbacks
-        if cb.name === event && cb.state === source
-            handled = cb.callback(payload)
-            break
-        end
-    end
-
-    if handled != Handled
-        do_event_r!(sm, ancestor(sm, source), event, payload)
-    end
-    return
-end
-
 function do_event!(
     sm::AbstractStateMachine,
     source::Union{Symbol,AbstractString},

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,3 +1,0 @@
-abstract type AbstractHsmState end
-abstract type AbstractHsmStateMachine end
-abstract type AbstractEventReturn end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,57 +2,55 @@ using Test
 using Hsm
 
 mutable struct MyStateMachine <: Hsm.AbstractStateMachine
-    ctx::Hsm.StateMachineContext
+    context::Hsm.StateMachineContext
     foo::Int
 end
-mysm = MyStateMachine(
-    Hsm.StateMachineContext(),
-    1
-)
+mysm = MyStateMachine(Hsm.StateMachineContext(), 1)
+
 Hsm.register_events!(mysm) do sm
+    Hsm.add_state!(sm, name = :Top, ancestor = :Root)
+    Hsm.add_state!(sm, name = :S, ancestor = :Top)
+    Hsm.add_state!(sm, name = :S1, ancestor = :S)
+    Hsm.add_state!(sm, name = :S11, ancestor = :S1)
+    Hsm.add_state!(sm, name = :S2, ancestor = :S)
+    Hsm.add_state!(sm, name = :S21, ancestor = :S2)
+    Hsm.add_state!(sm, name = :S211, ancestor = :S21)
 
-    Hsm.add_state!(sm, name = :Top, ancestor=:Root)
-    Hsm.add_state!(sm, name = :S, ancestor=:Top)
-    Hsm.add_state!(sm, name = :S1, ancestor=:S)
-    Hsm.add_state!(sm, name = :S11, ancestor=:S1)
-    Hsm.add_state!(sm, name = :S2, ancestor=:S)
-    Hsm.add_state!(sm, name = :S21, ancestor=:S2)
-    Hsm.add_state!(sm, name = :S211, ancestor=:S21)
-
-
-    Hsm.on_initialize!(sm, :Top) do 
-        Hsm.transition!(sm, :S2) do 
+    Hsm.on_initial!(sm, :Top) do
+        Hsm.transition!(sm, :S2) do
             sm.foo = 0
         end
     end
 
     ## S
-
-    Hsm.on_initialize!(sm, :S) do 
-        Hsm.transition!(sm, :S11) do 
+    Hsm.on_initial!(sm, :S) do
+        Hsm.transition!(sm, :S11) do
         end
     end
+
     Hsm.on_event!(sm, :S, :E) do payload
-        Hsm.transition!(sm, :S11) do 
+        Hsm.transition!(sm, :S11) do
         end
         return Hsm.Handled
     end
+
     Hsm.on_event!(sm, :S, :I) do payload
         if sm.foo == 1
             sm.foo = 0
             return Hsm.Handled
         end
-        return Hsm.NotHandled 
+        return Hsm.NotHandled
     end
 
     ## S1
-    Hsm.on_initialize!(sm, :S1) do 
+    Hsm.on_initial!(sm, :S1) do
         Hsm.transition!(sm, :S11) do
         end
         return Hsm.Handled
     end
+
     Hsm.on_event!(sm, :S1, :A) do payload
-        Hsm.transition!(sm, :S1) do 
+        Hsm.transition!(sm, :S1) do
         end
         return Hsm.Handled
     end
@@ -79,7 +77,7 @@ Hsm.register_events!(mysm) do sm
         return Hsm.NotHandled
     end
 
-    Hsm.on_event!(sm, :S1, :F) do payload 
+    Hsm.on_event!(sm, :S1, :F) do payload
         Hsm.transition!(sm, :S211) do
         end
     end
@@ -88,11 +86,10 @@ Hsm.register_events!(mysm) do sm
         return Hsm.Handled
     end
 
-
     ## S11
     Hsm.on_event!(sm, :S11, :D) do payload
         if sm.foo == 1
-            Hsm.transition!(sm, :S1) do 
+            Hsm.transition!(sm, :S1) do
                 sm.foo = 0
             end
             return Hsm.Handled
@@ -100,35 +97,32 @@ Hsm.register_events!(mysm) do sm
         return Hsm.NotHandled
     end
 
-    Hsm.on_event!(sm, :S11, :G) do  payload
+    Hsm.on_event!(sm, :S11, :G) do payload
         Hsm.transition!(sm, :S211) do
         end
         return Hsm.Handled
     end
-    
-    Hsm.on_event!(sm, :S11, :H) do  payload
-        Hsm.transition!(sm, :S) do 
+
+    Hsm.on_event!(sm, :S11, :H) do payload
+        Hsm.transition!(sm, :S) do
         end
         return Hsm.Handled
     end
-    
-
-
 
     ## S2
-    Hsm.on_initialize!(sm, :S2) do 
+    Hsm.on_initial!(sm, :S2) do
         Hsm.transition!(sm, :S211) do
         end
     end
 
     Hsm.on_event!(sm, :S2, :C) do payload
-        Hsm.transition!(sm, :S1) do 
+        Hsm.transition!(sm, :S1) do
         end
         return Hsm.Handled
     end
 
     Hsm.on_event!(sm, :S2, :F) do payload
-        Hsm.transition!(sm, :S11) do 
+        Hsm.transition!(sm, :S11) do
         end
         return Hsm.Handled
     end
@@ -141,50 +135,49 @@ Hsm.register_events!(mysm) do sm
         return Hsm.NotHandled
     end
 
-
     ## S21
-
-    Hsm.on_initialize!(sm, :S21) do 
+    Hsm.on_initial!(sm, :S21) do
         Hsm.transition!(sm, :S211) do
             # The previous S21 also transitions to S211? Is that right?
         end
     end
+
     Hsm.on_event!(sm, :S21, :A) do payload
-        Hsm.transition!(sm, :S21) do 
+        Hsm.transition!(sm, :S21) do
         end
         return Hsm.Handled
     end
+
     Hsm.on_event!(sm, :S21, :B) do payload
-        Hsm.transition!(sm, :S211) do 
+        Hsm.transition!(sm, :S211) do
         end
         return Hsm.Handled
     end
+
     Hsm.on_event!(sm, :S21, :G) do payload
-        Hsm.transition!(sm, :S11) do 
+        Hsm.transition!(sm, :S11) do
         end
         return Hsm.Handled
     end
 
     ## S211
-    Hsm.on_initialize!(sm, :S21) do
+    Hsm.on_initial!(sm, :S211) do
     end
+
     Hsm.on_event!(sm, :S211, :D) do payload
-        Hsm.transition!(sm, :S21) do 
+        Hsm.transition!(sm, :S21) do
         end
         return Hsm.Handled
     end
+
     Hsm.on_event!(sm, :S211, :H) do payload
-        Hsm.transition!(sm, :S) do 
+        Hsm.transition!(sm, :S) do
         end
         return Hsm.Handled
     end
-    
 end;
 
-
-
 @testset "Basics" begin
-
     @test Hsm.ancestor(mysm, :Top) == :Root
     @test Hsm.ancestor(mysm, :S) == :Top
     @test Hsm.ancestor(mysm, :S1) == :S
@@ -193,9 +186,8 @@ end;
     @test Hsm.ancestor(mysm, :S21) == :S2
     @test Hsm.ancestor(mysm, :S211) == :S21
 
-
     @test Hsm.ischildof(mysm, :S, :Top)
-    
+
     @test Hsm.ischildof(mysm, :S1, :S)
     @test Hsm.ischildof(mysm, :S1, :Top)
 
@@ -215,14 +207,10 @@ end;
     @test Hsm.ischildof(mysm, :S211, :S)
     @test Hsm.ischildof(mysm, :S211, :Top)
 
-
     @test Hsm.find_lca(mysm, :S211, :S11) == :S
-
 end
 
-
 @testset "All 4 Level HSM transitions" begin
-    
     Hsm.transition!(mysm, :Top)
     @test Hsm.current(mysm) == :S211
 
@@ -291,14 +279,9 @@ end
 
     Hsm.dispatch!(mysm, :C)
     @test Hsm.current(mysm) == :S11
-
-    
 end
 
-
-
 @testset "Allocation Free" begin
-    
     function test(mysm)
         Hsm.transition!(mysm, :Top)
         Hsm.dispatch!(mysm, :A)
@@ -326,7 +309,4 @@ end
     end
     precompile(test, (typeof(mysm),))
     @test 0 == @allocated test(mysm)
-
-    
 end
-

--- a/test/test_hsm.jl
+++ b/test/test_hsm.jl
@@ -252,15 +252,3 @@ function test(hsm)
 end
 precompile(test, (typeof(mysm),))
 @time test(mysm)
-
-function profile_test(sm, n)
-    for _ = 1:n
-        test(sm)
-    end
-end
-
-function profile_test2(sm, e, b, n)
-    for _ = 1:n
-        Hsm.dispatch!(sm, e, b)
-    end
-end


### PR DESCRIPTION
Ran a code formatter and fixed a testing error.

Renamed on_initialize! to on_initial! as it's the initial transition handler for a state and I used the wrong name in the original implementation.

Renamed ctx to context for clarity.